### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const roleAdmin = await Role.find(1)
 await roleAdmin.permissions().attach([
   createUsersPermission.id,
   updateUsersPermission.id,
-  deleteUsersPermission.is,
+  deleteUsersPermission.id,
   readUsersPermission.id
 ])
 ```
@@ -208,7 +208,7 @@ const roleAdmin = await Role.find(1)
 await roleAdmin.permissions().detach([
   createUsersPermission.id,
   updateUsersPermission.id,
-  deleteUsersPermission.is,
+  deleteUsersPermission.id,
   readUsersPermission.id
 ])
 ```
@@ -282,7 +282,7 @@ const user = await User.find(1)
 await user.permissions().attach([
   createUsersPermission.id,
   updateUsersPermission.id,
-  deleteUsersPermission.is,
+  deleteUsersPermission.id,
   readUsersPermission.id
 ])
 ```
@@ -294,7 +294,7 @@ const user = await User.find(1)
 await user.permissions().detach([
   createUsersPermission.id,
   updateUsersPermission.id,
-  deleteUsersPermission.is,
+  deleteUsersPermission.id,
   readUsersPermission.id
 ])
 ```


### PR DESCRIPTION
The readme contains a typo in example :

`deleteUsersPermission.is` change to > `deleteUsersPermission.id`