### PR TITLE
Added the missing users relationship in role model

### DIFF
--- a/src/Models/Role.js
+++ b/src/Models/Role.js
@@ -25,6 +25,10 @@ class Role extends Model {
     const permissions = await this.permissions().fetch()
     return permissions.rows.map(({ slug }) => slug)
   }
+  
+  users () {
+    return this.belongsToMany('App/Models/User')
+  }
 }
 
 module.exports = Role


### PR DESCRIPTION
The missing `users()` relationship has been added to allow queries such as this:
```js
  const Role = use('Role')
  const role = await Role.findByOrFail('slug', 'admin')
  const user = await role.users().first()

  console.log('user', user)
```